### PR TITLE
Content tree keyboard interactions - fix for broken checkbox indeterminate state

### DIFF
--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -165,3 +165,8 @@ article a:not(.stretched-link)[href^="http"]::after,
 .autocomplete-suggestions.dropdown-menu {
   padding: 0px;
 }
+
+
+.custom-checkbox .custom-control-input:indeterminate~.custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='3.8' viewBox='0 0 4 4' %3e%3cpath stroke='%23fff' d='M -0.1 2h4 '/%3e%3c/svg%3e");
+}

--- a/src/pages/sample/content-tree.tsx
+++ b/src/pages/sample/content-tree.tsx
@@ -3,7 +3,7 @@ import { Container, Row } from "@trimbleinc/modus-react-bootstrap"
 import TreeViewItem from "../../common/Tree/TreeViewItem"
 import TreeView from "../../common/Tree/TreeView"
 import { ModusIconsScripts } from "../../common/ExternalDependencyHelper"
-import "../../assets/css/test.scss"
+import "../../assets/css/main.scss"
 
 const ContentTreePage = props => {
   return (
@@ -13,7 +13,7 @@ const ContentTreePage = props => {
           <Row>
             <div className="col-12 col-lg-6 pt-5 mt-xl-5">
               <div style={{ width: "400px" }}>
-                {/* <ModusIconsScripts /> */}
+                <ModusIconsScripts />
                 <TreeView multiSelectCheckBox>
                   <TreeViewItem nodeId={1} label="Layout">
                     <TreeViewItem nodeId={2} label="Main Layout">


### PR DESCRIPTION
The bug is replicable only on a gatsby site on production,
sample gatsby site to view the bug - https://628247eb9daaae2324cfb465--remarkable-sunburst-705f95.netlify.app/

fixed site - https://deploy-preview-169--modus-react-bootstrap.netlify.app/components/content-tree/#MultiSelectionTree