### PR TITLE
fix minor accessibility issue with headings

### DIFF
--- a/src/common/TableOfContents.js
+++ b/src/common/TableOfContents.js
@@ -166,14 +166,14 @@ const TableOfContents = props => {
         </nav>
         {current && current.styleguideUrl && (
           <div>
-            <h5 className="pt-2 ml-3">More Information</h5>
+            <div className="h5 pt-2 ml-3">More Information</div>
             <ul className="list-unstyled pl-0 ml-0">
               <li>
                 <a
                   href={current.styleguideUrl}
                   className="nav-link text-dark text-decoration-none filter-desaturate"
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener"
                 >
                   Modus Style Guide
                 </a>


### PR DESCRIPTION
## Description

The 'On this page' text on right side menu is currently wrapped in a: `<h5 class="pt-2 ml-3">` this changes it to `<div class="h5 pt-2 ml-3">` to fix an accessibility warning in Lighthouse.


Lighthouse Audit:
[googlechrome.github.io/lighthouse/viewer/?psiurl=https%3A%2F%2Fmodus-react-bootstrap.trimble.com%2Fcomponents%2Fpagination%2F%23Example&strategy=desktop&category=accessibility&utm_source=lh-chrome-ext](https://googlechrome.github.io/lighthouse/viewer/?psiurl=https%3A%2F%2Fmodus-react-bootstrap.trimble.com%2Fcomponents%2Fpagination%2F%23Example&strategy=desktop&category=accessibility&utm_source=lh-chrome-ext)

Fixes: #202

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

n/a

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have tested my changes across the different browsers we support
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
